### PR TITLE
use vagrant-librarian-puppet for puppet module setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
-end
-
-gem 'librarian-puppet', :require => false

--- a/README.md
+++ b/README.md
@@ -22,12 +22,20 @@ SQRE credentials
     chmod 0700 .sqre
     ls -lad .sqre
 
+Vagrant plugins
+---------------
+
+    vagrant plugin install vagrant-hostmanager
+    vagrant plugin install vagrant-librarian-puppet
+    vagrant plugin install vagrant-digitalocean
+
+### Suggested for usage with virtualbox
+
+    vagrant plugin install vagrant-cachier
+
 Sandbox
 -------
 
     git clone git@github.com:lsst-sqre/sandbox-stackbuild.git
     cd sandbox-stackbuild
-    bundle install
-    bundle exec librarian-puppet install
     vagrant up --provider=digital_ocean
-    


### PR DESCRIPTION
Instead of installing librarian-puppet from a Gemfile and
invoking it manually, allow the vagrant-librarian-puppet plugin to
auto-magically install modules.
