### PR TITLE
add empty modules/ dir

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,6 +118,11 @@ Vagrant.configure('2') do |config|
     config.hostmanager.include_offline = false
   end
 
+  if Vagrant.has_plugin?('vagrant-librarian-puppet')
+    config.librarian_puppet.puppetfile_dir = "modules2"
+    config.librarian_puppet.placeholder_filename = ".gitkeep"
+  end
+
   puppet_script = <<-EOS.gsub(/^\s*/, '')
     if rpm -q puppet; then
       yum update -y puppet


### PR DESCRIPTION
The puppet provisioner requires that the puppet module source directory
exists before vagrant starts up.  Since vagrant-librarian-puppet has yet
created the modules dir before this check, we need to make sure it's
pre-created.
