### PR TITLE
(bugfix) select ssh public key based on ssh private key path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -143,7 +143,7 @@ if File.exist? "#{Dir.home}/.#{SANDBOX_GROUP}"
 else
   DO_API_TOKEN="<digitalocean api token>"
   SSH_PRIVATE_KEY_PATH="#{ENV['HOME']}/.ssh/id_rsa"
-  SSH_PUBLIC_KEY_PATH="#{ENV['USER']}/.ssh/id_rsa.pub"
+  SSH_PUBLIC_KEY_PATH="#{SSH_PRIVATE_KEY_PATH}.pub"
   SSH_PUBLIC_KEY_NAME=ENV['USER']
 end
 


### PR DESCRIPTION
The private key path was being generated based on `$USER` instead of `$HOME`,
which is a bug.  The path to the public key is now based upon the path
generated for the private key.
