### PR TITLE
peg installed puppet version number to 3.7.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,7 @@ Vagrant.configure('2') do |config|
   end
 
   # setup the remote repo needed to install a current version of puppet
-  config.puppet_install.puppet_version = :latest
+  config.puppet_install.puppet_version = '3.7.5'
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "manifests"


### PR DESCRIPTION
Puppet 4.0.0 was released today which, among potential compatiblity issues, is
packaged differently and this broke the bootstrap shell script
(https://github.com/petems/puppet-install-shell/) used by the
vagrant-puppet-install plugin.  The puppet version is being hard coded as a
short term work around. See:
https://github.com/petems/puppet-install-shell/issues/40
