### PR TITLE
update puppet-lsstack module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,4 +11,4 @@ mod 'pltraining/dirtree', '~> 0.2.2'
 #mod 'jhoblitt/lsststack', :git => 'https://github.com/lsst-sqre/puppet-lsststack.git'
 mod 'jhoblitt/lsststack',
   :git => 'https://github.com/lsst-sqre/puppet-lsststack.git',
-  :ref => '882d61e782d3fd9bc8ba8e1b6c5c74ff7d6fa467'
+  :ref => '44dc389b4397d9bb2f7a6474f93726f82c6efe53'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -4,18 +4,19 @@ FORGE
     camptocamp-augeas (1.4.2)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     jhoblitt-sysstat (1.1.0)
-    maestrodev-wget (1.7.1)
+    maestrodev-wget (1.7.3)
     petems-swap_file (1.0.1)
       puppetlabs-stdlib (>= 3.2.0)
     pltraining-dirtree (0.2.2)
-    puppetlabs-stdlib (4.9.0)
+    puppetlabs-stdlib (4.12.0)
     puppetlabs-vcsrepo (1.2.0)
-    stahnma-epel (1.1.1)
+    stahnma-epel (1.2.2)
+      puppetlabs-stdlib (>= 3.0.0)
 
 GIT
   remote: https://github.com/lsst-sqre/puppet-lsststack.git
-  ref: 882d61e782d3fd9bc8ba8e1b6c5c74ff7d6fa467
-  sha: 882d61e782d3fd9bc8ba8e1b6c5c74ff7d6fa467
+  ref: 44dc389b4397d9bb2f7a6474f93726f82c6efe53
+  sha: 44dc389b4397d9bb2f7a6474f93726f82c6efe53
   specs:
     jhoblitt-lsststack (0.1.0)
       maestrodev-wget (< 1.8.0, >= 1.7.0)


### PR DESCRIPTION
To pickup improvements to the `lsststack::newinstall` defined type.
